### PR TITLE
fix(security): Update Packagist security advisories URL to official domain

### DIFF
--- a/src/Domain/Insights/ForbiddenSecurityIssues.php
+++ b/src/Domain/Insights/ForbiddenSecurityIssues.php
@@ -15,7 +15,7 @@ use Throwable;
 
 final class ForbiddenSecurityIssues extends Insight implements HasDetails, GlobalInsight
 {
-    private const PACKAGIST_ADVISORIES_URL = 'https://repo.packagist.org/api/security-advisories/';
+    private const PACKAGIST_ADVISORIES_URL = 'https://packagist.org/api/security-advisories/';
 
     /**
      * @var array<Details>


### PR DESCRIPTION
Description:

This PR updates the Packagist security advisories API endpoint from the deprecated repo.packagist.org subdomain to the current canonical domain packagist.org.

Changes:

    Replaces https://repo.packagist.org/api/security-advisories/ with https://packagist.org/api/security-advisories/
    Ensures continued functionality of dependency vulnerability checks

Justification:
Packagist has migrated its API endpoints to the main domain, as reflected in their official [API documentation](https://packagist.org/apidoc#get-security-advisories). The previous subdomain may become unsupported in future updates.

Verification:
Manual testing confirms the new endpoint returns advisory data as expected. Existing test suites pass successfully.

References:
[Packagist API Documentation](https://packagist.org/apidoc#get-security-advisories)